### PR TITLE
Assemble with optimizations, so run doesn't rebuild

### DIFF
--- a/1.20/s2i/bin/assemble
+++ b/1.20/s2i/bin/assemble
@@ -18,7 +18,7 @@ if [ ! -z $PROXY ]; then
 fi
 
 echo "---> Installing application source..."
-cargo build
+cargo build --release
 
 echo "---> Build completed at $(date)"
 

--- a/1.20/s2i/bin/usage
+++ b/1.20/s2i/bin/usage
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cat <<EOF
-This is a S2I Rust 2.0 base image. To use it, install S2I: https://github.com/openshift/source-to-image
+This is a S2I Rust 1.20 base image. To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 

--- a/1.7/s2i/bin/assemble
+++ b/1.7/s2i/bin/assemble
@@ -15,7 +15,7 @@ if [ ! -z $PROXY ]; then
 fi
 
 echo "---> Installing application source..."
-cargo build
+cargo build --release
 
 echo "---> Build completed at $(date)"
 


### PR DESCRIPTION
The `assemble` scripts were using plain `cargo build`, which only
produces `target/debug/` binaries.  Then when the `run` scripts used
`cargo run --release`, Cargo had to build `target/release/` binaries
first.  The assembled debug build was a waste.

The simple solution is to assemble with `cargo build --release`.