### PR TITLE
support older bash and fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation
 To prepare the builder image:
 ```shell
 $ git clone https://github.com/openshift-s2i/s2i-rust.git
-$ cd sti-rust
+$ cd s2i-rust
 $ make build
 ```
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -72,7 +72,7 @@ for dir in ${dirs}; do
 
   IMAGE_NAME="${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 
-  if [[ -v TEST_MODE ]]; then
+  if [[ -z ${TEST_MODE+x} ]]; then
     IMAGE_NAME+="-candidate"
   fi
 
@@ -85,7 +85,7 @@ for dir in ${dirs}; do
     docker_build_with_version Dockerfile
   fi
 
-  if [[ -v TEST_MODE ]]; then
+  if [[ -z ${TEST_MODE+x} ]]; then
     IMAGE_NAME=${IMAGE_NAME} test/run
 
     if [[ $? -eq 0 ]] && [[ "${TAG_ON_SUCCESS}" == "true" ]]; then


### PR DESCRIPTION
Add support for an older version of bash that comes with macOS and fix a typo in the README.